### PR TITLE
Delete gazebo_ros_pkgs from workspace to fix camera plugin of gazebo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "gazebo_ros_pkgs"]
-	path = gazebo_ros_pkgs
-	url = https://github.com/ros-simulation/gazebo_ros_pkgs
-	branch = noetic-devel
 [submodule "cwru_stickyfingers"]
 	path = cwru_stickyfingers
 	url = https://github.com/cwru-robotics/cwru_stickyfingers


### PR DESCRIPTION
Current version of gazebo_ros_pkgs in the repo leads to camera plugin crash.
As of today the apt pack is more up to date and in sync with the gazebo 11 from noetic. 
Therefore its safe to delete gazebo_ros_pkgs from workspace.

***
After deleting the gazebo_ros_pkgs and a completely clean catkin_make could run the code of chapter 16 of the Learning ROS for Robotics Programming.

![Screenshot from 2021-05-12 10-31-03](https://user-images.githubusercontent.com/1910865/117909641-2fa19f00-b30d-11eb-818a-8e07a24e78bd.png)


***
confirm gazeo versions
```
sudo apt list --installed | grep gazebo
```
output
```
gazebo11-common/now 11.3.0-1~focal all [installed,upgradable to: 11.5.0-1~focal]
gazebo11-plugin-base/focal,now 11.3.0-1~focal amd64 [installed,automatic]
gazebo11/now 11.3.0-1~focal amd64 [installed,upgradable to: 11.5.0-1~focal]
libgazebo11-dev/now 11.3.0-1~focal amd64 [installed,upgradable to: 11.5.0-1~focal]
libgazebo11/now 11.3.0-1~focal amd64 [installed,upgradable to: 11.5.0-1~focal]
ros-noetic-gazebo-dev/focal,now 2.9.2-1focal.20210423.224909 amd64 [installed]
ros-noetic-gazebo-msgs/focal,now 2.9.2-1focal.20210423.233721 amd64 [installed]
ros-noetic-gazebo-plugins/focal,now 2.9.2-1focal.20210424.001717 amd64 [installed]
ros-noetic-gazebo-ros-control/focal,now 2.9.2-1focal.20210424.001722 amd64 [installed]
ros-noetic-gazebo-ros-pkgs/focal,now 2.9.2-1focal.20210424.004244 amd64 [installed]
ros-noetic-gazebo-ros/focal,now 2.9.2-1focal.20210424.001031 amd64 [installed]
ros-noetic-gazebo-video-monitor-msgs/focal,now 0.6.0-1focal.20210423.225043 amd64 [installed]
```